### PR TITLE
adds a mobile header and popover menu

### DIFF
--- a/src/components/CloseButton.astro
+++ b/src/components/CloseButton.astro
@@ -1,0 +1,22 @@
+---
+import CloseIcon from "./icons/CloseIcon.astro";
+
+const { popovertarget } = Astro.props;
+---
+
+<button class="close-button" popovertarget={popovertarget} popovertargetaction="hide">
+  <span class="sr-only"><slot /></span>
+  <CloseIcon />
+</button>
+
+<style>
+  .close-button {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    width: 2.5em;
+    height: 2.5em;
+    padding: 0.5em;
+  }
+</style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,0 +1,117 @@
+---
+import ThemeSwitcher from './ThemeSwitcher.astro';
+import MenuButton from './MenuButton.astro';
+import CloseButton from './CloseButton.astro';
+
+type Pattern = {
+  name: string;
+  id: string;
+};
+
+const { patterns }: Record<string, Pattern[]> = Astro.props;
+---
+
+<header class="header">
+  <h1>Open Patterns</h1>
+
+  <MenuButton popovertarget="popover-nav">Menu</MenuButton>
+  
+  <!-- Mobile nav duplicated for semantic popover -->
+  <nav class="popover-nav" popover id="popover-nav">
+    <h2>Patterns</h2>
+    <ul>
+      {patterns.map(pattern => (
+        <li>
+          <a href={`#${pattern.id}`}>{pattern.name}</a>
+        </li>
+      ))}
+    </ul>
+    <CloseButton popovertarget="popover-nav">Close</CloseButton>
+    <ThemeSwitcher />
+  </nav>
+</header>
+
+<script>
+  const mobileLinks = document.querySelectorAll<HTMLElement>('.popover-nav > ul > li > a');
+  mobileLinks.forEach(link => {
+    link.addEventListener('click', () => {
+      // Close the popover when a link is clicked
+      link.closest<HTMLElement>('.popover-nav')?.hidePopover();
+    });
+  });
+</script>
+
+<style is:global>
+  html {
+    scroll-padding-block-start: calc((1rem + 60px));
+  }
+
+  .header {
+    background-color: var(--sidebar-bg);
+    
+    @media (min-width: 769px) {
+      display: none;
+    }
+    
+    @media (max-width: 768px) {
+      position: sticky;
+      top: 0;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding-block: 0.75rem;
+      padding-inline: 3rem;
+      border-block-end: 1px solid var(--border-color);
+      z-index: 1;
+    }
+
+    > h1 {
+      margin: 0;
+      font-size: 1.5em;
+    }
+  }
+  
+  .popover-nav {
+    > ul {
+      list-style: none;
+      padding: 0;
+  
+      > li {
+        margin-bottom: 0.75rem;
+      }
+    }
+  }
+
+  .popover-nav {
+    inset: 2rem;
+    overflow-y: auto;
+    margin: auto;
+    width: auto;
+    border-radius: 8px;
+    border: 1px solid var(--border-color);
+    padding: 1rem;
+    background-color: var(--sidebar-bg);
+    max-height: calc(100dvh - 4rem);
+
+    &::backdrop {
+      background-color: rgba(0, 0, 0, 0.5);
+    }
+    @media (min-width: 768px) {
+      display: none;
+    }
+  }
+
+  .menu-button {
+    flex-shrink: 0;
+    @media (min-width: 769px) {
+      display: none;
+    }
+  }
+
+  .close-button {
+    position: absolute;
+    left: auto;
+    right: 1rem;
+    top: 1rem;
+  }
+</style>

--- a/src/components/MenuButton.astro
+++ b/src/components/MenuButton.astro
@@ -1,0 +1,40 @@
+---
+import CloseIcon from "./icons/CloseIcon.astro";
+import MenuIcon from "./icons/MenuIcon.astro";
+
+const { popovertarget } = Astro.props;
+---
+
+<button class="menu-button" popovertarget={popovertarget} popovertargetaction="toggle">
+  <span class="sr-only"><slot /></span>
+  <MenuIcon class="burger" />
+  <CloseIcon class="close" />
+</button>
+
+<script>
+  const menuButton = document.querySelector('.menu-button');
+  const popover = document.getElementById(menuButton!.getAttribute('popovertarget')!);
+  popover?.addEventListener('toggle', (event: ToggleEvent) => {
+    menuButton?.classList.toggle('active', event.newState === 'open');
+  });
+</script>
+
+<style is:global>
+  .menu-button {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    width: 2.5em;
+    height: 2.5em;
+    padding: 0.5em;
+  }
+
+  .menu-button:not(.active) .close {
+    display: none;
+  }
+
+  .menu-button.active .burger {
+    display: none;
+  }
+</style>

--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -1,31 +1,20 @@
 ---
-// src/components/Sidebar.astro
-
-// highlight-start
-import fs from 'node:fs/promises';
-import path from 'node:path';
-// highlight-end
 import ThemeSwitcher from './ThemeSwitcher.astro';
 
-// highlight-start
-// Get the absolute path to the patterns directory
-const patternsPath = path.resolve(process.cwd(), 'src/patterns');
+type Pattern = {
+  name: string;
+  id: string;
+};
 
-// Read all entries in the directory, filter for sub-directories, and get their names
-const patternNames = (await fs.readdir(patternsPath, { withFileTypes: true }))
-  .filter(dirent => dirent.isDirectory())
-  .map(dirent => dirent.name);
-
-const patterns = patternNames.map(name => {
-  const id = name.toLowerCase().replace(/\s+/g, '-');
-  return { name, id };
-});
-// highlight-end
+const { patterns }: Record<string, Pattern[]> = Astro.props;
 ---
-<aside class="sidebar">
+
+<aside class="sidenav">
   <h1>Open Patterns</h1>
+  
   <ThemeSwitcher />
-  <nav>
+
+  <nav class="sidebar-nav">
     <h2>Patterns</h2>
     <ul>
       {patterns.map(pattern => (
@@ -38,17 +27,33 @@ const patterns = patternNames.map(name => {
 </aside>
 
 <style>
-  h1 {
-    margin-top: 0;
+  .sidenav {
+    background-color: var(--sidebar-bg);
+    width: 280px;
+    flex-shrink: 0;
+    padding: 1.5rem;
+    border-inline-end: 1px solid var(--border-color);
+    overflow-y: auto;
+    
+    @media (max-width: 768px) {
+      display: none;
+    }
+    > h1 {
+      margin-top: 0;
+    }
   }
-  nav {
+  .sidebar-nav {
     margin-top: 2rem;
   }
-  nav ul {
-    list-style: none;
-    padding: 0;
-  }
-  nav li {
-    margin-bottom: 0.75rem;
+  
+  .sidebar-nav {
+    > ul {
+      list-style: none;
+      padding: 0;
+  
+      > li {
+        margin-bottom: 0.75rem;
+      }
+    }
   }
 </style>

--- a/src/components/icons/CloseIcon.astro
+++ b/src/components/icons/CloseIcon.astro
@@ -1,0 +1,13 @@
+---
+const { class: className } = Astro.props;
+---
+
+<svg
+  viewBox="0 0 24 24"
+  xmlns="http://www.w3.org/2000/svg"
+  aria-hidden="true"
+  class:list={className}
+>
+  <line x1="6" y1="6" x2="18" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <line x1="18" y1="6" x2="6" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/components/icons/MenuIcon.astro
+++ b/src/components/icons/MenuIcon.astro
@@ -1,0 +1,14 @@
+---
+const { class: className } = Astro.props;
+---
+
+<svg
+  viewBox="0 0 24 24"
+  xmlns="http://www.w3.org/2000/svg"
+  aria-hidden="true"
+  class:list={className}
+>
+  <rect x="4" y="6" width="16" height="2" rx="1" fill="currentColor"/>
+  <rect x="4" y="11" width="16" height="2" rx="1" fill="currentColor"/>
+  <rect x="4" y="16" width="16" height="2" rx="1" fill="currentColor"/>
+</svg>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,9 +4,9 @@ import Layout from '../layouts/Layout.astro';
 import Sidebar from '../components/Sidebar.astro';
 import Pattern from '../components/Pattern.astro';
 
-// highlight-start
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import Header from '../components/Header.astro';
 
 // Get the absolute path to the patterns directory
 const patternsPath = path.resolve(process.cwd(), 'src/patterns');
@@ -16,12 +16,17 @@ const patternsPath = path.resolve(process.cwd(), 'src/patterns');
 const patternNames = (await fs.readdir(patternsPath, { withFileTypes: true }))
   .filter(dirent => dirent.isDirectory())
   .map(dirent => dirent.name);
-// highlight-end
+
+const patterns = patternNames.map(name => {
+  const id = name.toLowerCase().replace(/\s+/g, '-');
+  return { name, id };
+});
 ---
 
 <Layout title="Open Patterns">
+  <Header patterns={patterns} />
   <main class="app-container">
-    <Sidebar />
+    <Sidebar patterns={patterns} />
     <div class="main-content">
       {patternNames.map(name => (
         <Pattern patternName={name} />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -16,21 +16,16 @@ body {
   background-color: var(--bg-color);
   color: var(--text-color);
   transition: background-color 0.3s ease, color 0.3s ease;
+  min-height: 100dvh;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+  }
 }
 
 .app-container {
   display: flex;
   height: 100vh;
-}
-
-.sidebar {
-  width: 280px;
-  flex-shrink: 0;
-  background-color: var(--sidebar-bg);
-  border-right: 1px solid var(--border-color);
-  padding: 1.5rem;
-  overflow-y: auto;
-  transition: background-color 0.3s ease, border-color 0.3s ease;
 }
 
 .main-content {
@@ -67,4 +62,15 @@ pre {
 
 code {
   font-family: inherit;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
 }


### PR DESCRIPTION
This change adds a very crude version of a mobile header and makes some minimal structural changes to the existing sidenav. This makes the page basically work on mobile, though a lot of things around spacing, typography and theming can still be improved.

<img width="478" height="473" alt="image" src="https://github.com/user-attachments/assets/a2cce4bc-2f1b-43a1-8355-36d20aa7bfde" />

<img width="476" height="567" alt="image" src="https://github.com/user-attachments/assets/aace6fb7-c8f3-41cf-948f-1a4c217867ed" />
